### PR TITLE
Fix implicitly global and unused variables

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,5 +1,3 @@
-var window_id = -1;
-var previous_selection = "";
 var flag_update_shape_of_div = false;
 var flag_close_div_click = false;
 var mouse_down_time = new Date().getTime();
@@ -100,16 +98,16 @@ function updateShapeOfDiv() {
 
 async function requestTranslation(selection, target_language) {
     let gitignore_path = chrome.runtime.getURL("env.gitignore");
-    res_json = await getLocalParameter(gitignore_path);
-    key = res_json['key'];
+    let res_json = await getLocalParameter(gitignore_path);
+    let key = res_json['key'];
     console.log("Requestting translate service...");
     let response_json = await fetch(`https://translate-pa.googleapis.com/v1/translate?params.client=gtx&query.source_language=en&query.target_language=${target_language}&query.display_language=en-GB&query.text=${selection}&key=${key}&data_types=TRANSLATION&data_types=SENTENCE_SPLITS&data_types=BILINGUAL_DICTIONARY_FULL`)
         .then( response => response.json() );
 
     // let response_json = await response.json();
-    translatedText = response_json['translation'];
-    language = response_json['sourceLanguage'];
-    output = {'translatedText': translatedText, 'detectedLanguage': {'language': language}}
+    let translatedText = response_json['translation'];
+    let language = response_json['sourceLanguage'];
+    let output = {'translatedText': translatedText, 'detectedLanguage': {'language': language}}
     // console.log("response_json: ", response_json);
     // console.log("output: ", output);
     return output;
@@ -160,12 +158,12 @@ async function get_output_from_word_translation(selection) {
     let response_json = await response.json();
 
     var output = "<b>" + selection + "&nbsp;" + response_json[0]['phonetic'] + "</b>" + "<br>"
-    limitation_per_partOfSpeech = 3;
+    let limitation_per_partOfSpeech = 3;
     for (var i = 0; i < response_json[0]['meanings'].length; i++) { 
-        let currenct = response_json[0]['meanings'][i];
-        for (var j = 0; j < Math.min(limitation_per_partOfSpeech, currenct['definitions'].length); j++) {
-            let definition = currenct['definitions'][j]['definition'];
-            output += "[" + currenct['partOfSpeech'] + "]&nbsp;" + definition + "<br>"
+        let current = response_json[0]['meanings'][i];
+        for (var j = 0; j < Math.min(limitation_per_partOfSpeech, current['definitions'].length); j++) {
+            let definition = current['definitions'][j]['definition'];
+            output += "[" + current['partOfSpeech'] + "]&nbsp;" + definition + "<br>"
         }
     }
     output += "<a href=" + word_request_url + ">More>></a>";
@@ -178,7 +176,7 @@ function check_valid_selection(selection) {
 
     // special letter
     if (selection.length <= 1) return false;
-    spe_cnt = digits.length;
+    let spe_cnt = digits.length;
     // selection.length > 0 && selection != ' '
     const spe_list = ["[", "`", "!", "@", "#", "$", "%", "^", "&", "*", 
         "(", ")", "_", "+", "-", "=", "[", "\\", "]", "{", "}", ";", "'", ":", '"', "|", ",", ".", 
@@ -213,7 +211,7 @@ function getChineseRatio(str) {
 
 // trigger when mouse up
 window.addEventListener('mouseup', function (evt) {
-    mouse_up_time = new Date().getTime();
+    let mouse_up_time = new Date().getTime();
     var current_click_for_request = Date.now();
     if (flag_update_shape_of_div === true) {
         updateShapeOfDiv();
@@ -241,7 +239,6 @@ window.addEventListener('mouseup', function (evt) {
                 || mouse_up_time - mouse_down_time >= 200 // this click for select text again, one click not double clicks
             )
         ) {
-        previous_selection = selection;
         (async() => {
             let extensionOn = await readLocalStorage('extensionOn', true);
             if (extensionOn !== true) {

--- a/popup.js
+++ b/popup.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (data.selectedLanguage !== undefined) {
             document.getElementById('targetLanguage').value = data.selectedLanguage;
         } else {
-            selectedLanguage = 'zh';
+            let selectedLanguage = 'zh';
             chrome.storage.local.set({ 'selectedLanguage': selectedLanguage });
             document.getElementById('targetLanguage').value = selectedLanguage;
         }
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (data.dictionaryFeature !== undefined) {
             document.getElementById('dictionaryFeature').checked = data.dictionaryFeature;
         } else {
-            dictionaryFeature = false;
+            let dictionaryFeature = false;
             chrome.storage.local.set({ 'dictionaryFeature': dictionaryFeature });
             document.getElementById('dictionaryFeature').checked = dictionaryFeature;
         }
@@ -25,13 +25,13 @@ document.addEventListener('DOMContentLoaded', function() {
         if (data.extensionOn !== undefined) {
             document.getElementById('extensionOn').checked = data.extensionOn;
         } else {
-            extensionOn = true;
+            let extensionOn = true;
             chrome.storage.local.set({ 'extensionOn': extensionOn });
             document.getElementById('extensionOn').checked = extensionOn;
         }
-        language = document.getElementById("language-selection-line");
-        target_language = document.getElementById("targetLanguage");
-        dictionary = document.getElementById("dictionary-feature-line");
+        let language = document.getElementById("language-selection-line");
+        let target_language = document.getElementById("targetLanguage");
+        let dictionary = document.getElementById("dictionary-feature-line");
         if (document.getElementById('extensionOn').checked == true) {
             language.style.color = 'black';
             target_language.style.color = 'black';
@@ -61,9 +61,9 @@ document.getElementById('dictionaryFeature').addEventListener('change', function
 // extensionOn
 document.getElementById('extensionOn').addEventListener('change', function() {
     var extensionOn = this.checked;
-    language = document.getElementById("language-selection-line");
-    target_language = document.getElementById("targetLanguage");
-    dictionary = document.getElementById("dictionary-feature-line");
+    let language = document.getElementById("language-selection-line");
+    let target_language = document.getElementById("targetLanguage");
+    let dictionary = document.getElementById("dictionary-feature-line");
     if (extensionOn === false) {
         language.style.color = 'silver';
         target_language.style.color = 'silver';


### PR DESCRIPTION
Fix implicitly global and unused variables

- Added `let` declarations to implicitly global variables in `content.js` and `popup.js` to prevent global namespace pollution and ensure block-scoping.
- Removed unused global variables `window_id` and `previous_selection` in `content.js`.
- Fixed typo `currenct` to `current` in `content.js`.

---
*PR created automatically by Jules for task [10574583092147309377](https://jules.google.com/task/10574583092147309377) started by @wa008*